### PR TITLE
Make Makefile executable

### DIFF
--- a/OTSO/Makefile
+++ b/OTSO/Makefile
@@ -1,7 +1,7 @@
+#! /usr/bin/make
 # Original Author: Christian Steigies (28/6/2024)
 # Slightly modified by Nicholas Larsen to work easier within the existing OTSO framework (28/08/2024)
 
-#! /usr/bin/make
 SHELL := bash
 .ONESHELL:
 .SHELLFLAGS := -eu -o pipefail -c


### PR DESCRIPTION
The shebang needs to be in the first line of the script. Then, when the Makefile is executable, you can run it also with:
./Makefile